### PR TITLE
Remove release notes generation & use existing label

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,10 @@ Was the label created.
 
 Label URL.
 
-### `issue-list`
-
-A list of moved issues, formatted for Slack.
-
 ## Example usage
 
 ```yaml
-uses: perdoo/linear-workflow-state-action@v0.3.0
+uses: perdoo/linear-workflow-state-action@v0.4.0
 with:
   linearApiKey: ${{ secrets.LINEAR_API_KEY }}
   fromStateId: 12345

--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ _Optional._ The name of a new label to be created and added to the issues.
 
 ## Outputs
 
-### `label-created`
-
-Was the label created.
-
 ### `url`
 
 Label URL.

--- a/action.yml
+++ b/action.yml
@@ -13,17 +13,12 @@ inputs:
   toStateId:
     description: Move to state id
     required: true
-  completedAfter:
-    description: Datetime when the issues were moved to the completed state
-    required: false
   label:
     description: The name of the label to add to the issues
     required: false
 outputs:
-  label-created:
-    description: Was the label created
   url:
     description: Label URL
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -1,25 +1,7 @@
 import * as core from "@actions/core";
 import { LinearClient } from "@linear/sdk";
 
-const ESCAPE = {
-  ">": "&gt;",
-  "<": "&lt;",
-  "&": "&amp;",
-  "\r\n": " ",
-  "\n": " ",
-  "\r": " ",
-};
-const ESPACE_REGEX = new RegExp(Object.keys(ESCAPE).join("|"), "gi");
-
-const linearToken = core.getInput("linearToken");
-const linearClient = new LinearClient({ apiKey: linearToken });
-const fromStateId = core.getInput("fromStateId");
-const toStateId = core.getInput("toStateId");
-const labelName = core.getInput("label");
-
-core.setSecret("linearToken");
-
-async function getIssues() {
+async function getIssues(linearClient, fromStateId) {
   const issues = await linearClient.issues({
     first: 100,
     filter: {
@@ -30,7 +12,7 @@ async function getIssues() {
   return issues;
 }
 
-async function createLabel() {
+async function createLabel(linearClient, labelName) {
   if (!labelName) {
     return null;
   }
@@ -39,9 +21,8 @@ async function createLabel() {
   const response = await linearClient.issueLabelCreate({ name: labelName });
   core.info(`Created label ${labelName}.`);
 
-  const labelUrl = `https://linear.app/perdoo/team/ENG/label/${encodeURIComponent(
-    labelName
-  )}`;
+  const encodedLabelName = encodeURIComponent(labelName);
+  const labelUrl = `https://linear.app/perdoo/label/${encodedLabelName}`;
 
   core.setOutput("url", labelUrl);
   core.setOutput("label-created", true);
@@ -49,140 +30,46 @@ async function createLabel() {
   return response._issueLabel.id;
 }
 
-async function updateIssues(issues, newLabelId) {
+async function moveIssues(toStateId, issues, labelId) {
   for (let i = 0; i < issues.nodes.length; i++) {
     const issue = issues.nodes[i];
     let payload = { stateId: toStateId };
 
-    if (newLabelId) {
+    if (labelId) {
       const labels = await issue.labels();
       const labelIds = labels.nodes.map(({ id }) => id);
-      if (!labelIds.includes(newLabelId)) {
-        payload["labelIds"] = labelIds.concat([newLabelId]);
+
+      if (!labelIds.includes(labelId)) {
+        payload["labelIds"] = labelIds.concat([labelId]);
         core.info(`Adding label "${labelName}" to "${issue.title}".`);
       }
     }
 
     await issue.update(payload);
 
-    core.info(
-      `Moved "${issue.title}" from state ${fromStateId} to ${toStateId}.`
-    );
+    core.info(`Moved "${issue.title}".`);
   }
 }
 
-const formatIssuesForSlack = async (labelId) => {
-  const label = await linearClient.issueLabel(labelId);
-  const bugs = await getBugs(label);
-  const chores = await getChores(label);
-  const fastTracks = await getFastTracks(label);
-  const projects = await getProjects(label);
-
-  return `
-*Fast Track*
-${formatIssues(fastTracks)}
-
-*Bugfixes*
-${formatIssues(bugs)}
-
-*Chores*
-${formatIssues(chores)}
-
-*Projects*
-${formatProjects(projects)}
-  `;
-};
-
-const getBugs = async (label) => {
-  let issues = await label.issues({
-    filter: { labels: { name: { eq: "Bug" } }, project: { null: true } },
-  });
-
-  return removeChildIssues(issues);
-};
-
-const getChores = async (label) => {
-  let issues = await label.issues({
-    filter: { labels: { name: { eq: "Chore" } }, project: { null: true } },
-  });
-
-  return removeChildIssues(issues);
-};
-
-const getFastTracks = async (label) => {
-  let issues = await label.issues({
-    filter: {
-      labels: { every: { name: { nin: ["Bug", "Chore"] } } },
-      project: { null: true },
-    },
-  });
-
-  return removeChildIssues(issues);
-};
-
-const removeChildIssues = (issues) => {
-  issues.nodes = issues.nodes.filter((issue) => issue._parent === undefined);
-  return issues;
-};
-
-const getProjects = async (label) => {
-  const issues = await label.issues({
-    filter: { project: { null: false } },
-  });
-  const projects = {};
-
-  for (let i = 0; i < issues.nodes.length; i++) {
-    const issue = issues.nodes[i];
-    if (!(issue._project.id in projects)) {
-      projects[issue._project.id] = await issue.project;
-    }
-  }
-
-  return Object.values(projects).sort(
-    (first, second) => second.progress - first.progress
-  );
-};
-
-const formatIssues = (issues) =>
-  issues.nodes
-    .map(({ title, url }) => `- <${url}|${escapeText(title)}>`)
-    .join("\n") || "_No tickets_";
-
-const escapeText = (text) =>
-  text.replace(ESPACE_REGEX, (match) => ESCAPE[match]);
-
-const formatProjects = (projects) =>
-  projects
-    .map(
-      ({ name, url, progress }) =>
-        `- <${url}|${escapeText(name)}>, ${formatProgress(progress)}`
-    )
-    .join("\n") || "_No projects_";
-
-const formatProgress = (progress) => {
-  if (progress === 1) {
-    return "Completed";
-  }
-  return `Progress: ${(progress * 100).toFixed()}%`;
-};
-
 async function run() {
   try {
-    const issues = await getIssues();
+    const linearToken = core.getInput("linearToken");
+    const linearClient = new LinearClient({ apiKey: linearToken });
+    const fromStateId = core.getInput("fromStateId");
+    const toStateId = core.getInput("toStateId");
+    const labelName = core.getInput("label");
+    core.setSecret("linearToken");
+
+    const issues = await getIssues(linearClient, fromStateId);
 
     if (!issues.nodes.length) {
       core.info("No issues found in the given workflow state.");
       return;
     }
 
-    const newLabelId = await createLabel();
+    const newLabelId = await createLabel(linearClient, labelName);
 
-    await updateIssues(issues, newLabelId);
-
-    if (newLabelId) {
-      const issueList = await formatIssuesForSlack(newLabelId);
-      core.setOutput("issue-list", issueList);
-    }
+    await moveIssues(toStateId, issues, newLabelId);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-workflow-state-action",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Changes:
- I've removed the part the generates release notes into a separate repo to allow generating them not just on releases.
- I've adjusted the code to be able to move issues in both Engineering and Backend teams.